### PR TITLE
Create description rule must start with uppercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ defmodule Schema do
         AbsintheLinter.Rules.DeprecationsHaveReason,
       ]
     )
+    |> Absinthe.Pipeline.insert_after(
+      Absinthe.Phase.Schema.ReformatDescriptions,
+      AbsintheLinter.Result
+    )
   end
 end
 ```

--- a/lib/absinthe_linter.ex
+++ b/lib/absinthe_linter.ex
@@ -22,10 +22,11 @@ defmodule AbsintheLinter do
 
   @default_rules [
     Rules.DeprecationsHaveReason,
+    Rules.DescriptionsAreCapitalized,
     Rules.EnumValuesHaveDescriptions,
     Rules.EnumValuesSortedAlphabetically,
-    Rules.RequireNonNullLists,
-    Rules.RequireListsOfNonNull
+    Rules.RequireListsOfNonNull,
+    Rules.RequireNonNullLists
   ]
 
   @doc """

--- a/lib/rules/descriptions_are_capitalized.ex
+++ b/lib/rules/descriptions_are_capitalized.ex
@@ -1,0 +1,33 @@
+defmodule AbsintheLinter.Rules.DescriptionsAreCapitalized do
+  @moduledoc """
+  Ensure descriptions start with a capital letter.
+  """
+  @behaviour Absinthe.Phase
+  alias Absinthe.Blueprint
+
+  def run(blueprint, _options \\ []) do
+    blueprint = Blueprint.prewalk(blueprint, &validate_node/1)
+
+    {:ok, blueprint}
+  end
+
+  defp validate_node(%{description: <<char::binary-size(1), _rest::binary>>} = node) do
+    if String.upcase(char) == char do
+      node
+    else
+      node |> AbsintheLinter.Rule.put_warning(error(node))
+    end
+  end
+
+  defp validate_node(node) do
+    node
+  end
+
+  defp error(node) do
+    %AbsintheLinter.Error{
+      message: "The description must start with a capital letter on node `#{node.name}`",
+      locations: [node.__reference__.location],
+      phase: __MODULE__
+    }
+  end
+end

--- a/lib/rules/require_list_of_non_null.ex
+++ b/lib/rules/require_list_of_non_null.ex
@@ -1,6 +1,6 @@
 defmodule AbsintheLinter.Rules.RequireListsOfNonNull do
   @moduledoc """
-  Ensure deprecations in your schema declare a reason.
+  Ensure lists don't have null values.
   """
   @behaviour Absinthe.Phase
   alias Absinthe.Blueprint

--- a/lib/rules/require_non_null_lists.ex
+++ b/lib/rules/require_non_null_lists.ex
@@ -1,6 +1,6 @@
 defmodule AbsintheLinter.Rules.RequireNonNullLists do
   @moduledoc """
-  Ensure deprecations in your schema declare a reason.
+  Ensure don't have null lists.
   """
   @behaviour Absinthe.Phase
   alias Absinthe.Blueprint

--- a/test/rules/descriptions_are_capitalized_test.exs
+++ b/test/rules/descriptions_are_capitalized_test.exs
@@ -1,0 +1,41 @@
+defmodule AbsintheLinter.Rules.DescriptionsAreCapitalizedTest do
+  use ExUnit.Case
+  import ExUnit.CaptureIO
+
+  @invalid_schema """
+  defmodule InvalidSchema do
+    use Absinthe.Schema
+
+    use AbsintheLinter, rules: [AbsintheLinter.Rules.DescriptionsAreCapitalized]
+
+    query do
+      @desc "invalid"
+      field :test, :string
+    end
+  end
+  """
+
+  @valid_schema """
+  defmodule ValidSchema do
+    use Absinthe.Schema
+
+    use AbsintheLinter, rules: [AbsintheLinter.Rules.DescriptionsAreCapitalized]
+
+    query do
+      field :test, :string, description: "Valid"
+    end
+  end
+  """
+
+  test "logs error" do
+    assert capture_io(:stderr, fn ->
+             Code.eval_string(@invalid_schema, [], __ENV__)
+           end) =~ "The description must start with a capital letter on node `test`"
+  end
+
+  test "does not logs error" do
+    refute capture_io(:stderr, fn ->
+             Code.eval_string(@valid_schema, [], __ENV__)
+           end) =~ "The description must start with a capital letter on node `test`"
+  end
+end


### PR DESCRIPTION
Descriptions are capitalized rule

This merge request adds a new validation rule to ensure descriptions in a schema start with an uppercase letter.